### PR TITLE
Use automated integration tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ pull_request_rules:
     conditions:
       - author~=dependabot\[bot\]|dependabot-preview\[bot\]
       - status-success=Travis CI - Pull Request
-      - label!=terraform
     actions:
       review:
         type: APPROVE

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ stages:
 if: branch = master OR type = pull_request
 
 before_install:
-   - tmpdaemon=$(mktemp)
-   - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
-   - sudo mv "$tmpdaemon" /etc/docker/daemon.json
-   - sudo systemctl daemon-reload
-   - sudo systemctl restart docker
-   - docker system info
+  - tmpdaemon=$(mktemp)
+  - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
+  - sudo mv "$tmpdaemon" /etc/docker/daemon.json
+  - sudo systemctl daemon-reload
+  - sudo systemctl restart docker
+  - docker system info
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,32 @@ language: minimal
 
 stages:
   - lint
+  - test
   - deploy
 
 if: branch = master OR type = pull_request
+
+before_install:
+   - tmpdaemon=$(mktemp)
+   - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
+   - sudo mv "$tmpdaemon" /etc/docker/daemon.json
+   - sudo systemctl daemon-reload
+   - sudo systemctl restart docker
+   - docker system info
 
 jobs:
   include:
     - stage: lint
       name: Project Syntax Verification
       script: make docker/run target=lint
+    - stage: test
+      name: Apply Terraform test configs in mockstack
+      install:
+        - make docker-compose/install
+        - make mockstack/up
+      script: make mockstack/pytest
+      after_script:
+        - make mockstack/clean
     - stage: deploy
       if: branch = master AND type = push AND repo = plus3it/terraform-aws-tardigrade-directory-service
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: minimal
 
 stages:
   - lint
-  - tests
+  - test
   - deploy
 
 if: branch = master OR type = pull_request

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 SHELL := /bin/bash
+ONLY_MOTO := true
 
 include $(shell test -f .tardigrade-ci || curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/plus3it/tardigrade-ci/master/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)

--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ Terraform module to create a directory
 
 ## Testing
 
-At the moment, testing is manual:
+Manual testing:
 
 ```
 # Replace "xxx" with an actual AWS profile, then execute the integration tests.
 export AWS_PROFILE=xxx 
 make terraform/pytest PYTEST_ARGS="-v --nomock"
+```
+
+For automated testing, PYTEST_ARGS is optional and no profile is needed:
+
+```
+make terraform/pytest PYTEST_ARGS="-v"
 ```
 
 <!-- BEGIN TFDOCS -->

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ make terraform/pytest PYTEST_ARGS="-v --nomock"
 For automated testing, PYTEST_ARGS is optional and no profile is needed:
 
 ```
+make mockstack/up
 make terraform/pytest PYTEST_ARGS="-v"
+make mockstack/clean
 ```
 
 <!-- BEGIN TFDOCS -->

--- a/tests/ad_connector/main.tf
+++ b/tests/ad_connector/main.tf
@@ -32,7 +32,7 @@ module "directory_service" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.7.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.11.0"
 
   name            = "tardigrade-test-directory-service-${random_string.domain.result}"
   cidr            = "10.0.0.0/16"

--- a/tests/basic/main.tf
+++ b/tests/basic/main.tf
@@ -14,7 +14,7 @@ resource "random_string" "domain" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.7.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.11.0"
 
   name            = "tardigrade-test-directory-service-${random_string.domain.result}"
   cidr            = "10.0.0.0/16"

--- a/tests/enable_sso/main.tf
+++ b/tests/enable_sso/main.tf
@@ -21,7 +21,7 @@ resource "random_string" "domain" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.7.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.11.0"
 
   name            = "tardigrade-test-directory-service-${random_string.domain.result}"
   cidr            = "10.0.0.0/16"

--- a/tests/microsoft_ad/main.tf
+++ b/tests/microsoft_ad/main.tf
@@ -14,7 +14,7 @@ resource "random_string" "domain" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.7.0"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=v3.11.0"
 
   name            = "tardigrade-test-directory-service-${random_string.domain.result}"
   cidr            = "10.0.0.0/16"


### PR DESCRIPTION
Uses tardigrade-ci's ability to run automated integration tests against a mock AWS stack.